### PR TITLE
Simphony wrapper fix

### DIFF
--- a/SiPANN/nn.py
+++ b/SiPANN/nn.py
@@ -69,8 +69,9 @@ LR_bent = import_nn.ImportLR(bent_FILE)
 def cartesian_product(arrays):
     la = len(arrays)
     dtype = np.find_common_type([a.dtype for a in arrays], [])
-    arr = np.empty([len(a) for a in arrays] + [la], dtype=dtype)
-    for i, a in enumerate(np.ix_(*arrays)):
+    l = [float(_a) for _a in arrays]
+    arr = np.empty([a.size for a in arrays] + [la], dtype=dtype)
+    for i, a in enumerate(l):
         arr[..., i] = a
     return arr.reshape(-1, la)
 

--- a/SiPANN/scee_int.py
+++ b/SiPANN/scee_int.py
@@ -1,5 +1,7 @@
 import numpy as np
 from simphony import Model
+from simphony.layout import Circuit
+from simphony.pins import Pin, PinList
 from simphony.tools import freq2wl
 from simphony.tools import wl2freq
 
@@ -62,15 +64,21 @@ class SimphonyWrapper(Model):
         be in values of nm. Defaults to an empty dictionary.
     """
 
-    pins = ("n1", "n2", "n3", "n4")  #: The default pin names of the device
-    freq_range = (
-        182800279268292.0,
-        205337300000000.0,
-    )  #: The valid frequency range for this model.
-
     def __init__(self, model, sigmas=dict()):
         self.model = model
         self.sigmas = sigmas
+        self.pins = PinList([Pin(self.model, "n1"), Pin(self.model, "n2"), Pin(self.model, "n3"), Pin(self.model, "n4")])  #: The default pin names of the device
+        self.model.pins = self.pins
+        self.model.circuit = Circuit(self.model)
+
+        self.model.freq_range = (
+            182800279268292.0,
+            205337300000000.0,
+        )  #: The valid frequency range for this model.
+
+        self.model.s_parameters = self.s_parameters
+        self.model.monte_carlo_s_parameters = self.monte_carlo_s_parameters
+        self.model.regenerate_monte_carlo_parameters = self.regenerate_monte_carlo_parameters
 
         # save actual parameters for switching back from monte_carlo
         self.og_params = self.model.__dict__.copy()


### PR DESCRIPTION
PR with 2 bug fixes:

First of which is raised when the `racetrack_sb_rr` model in `comp.py` is used by Simphony's SipannWrapper in a circuit. The following error is raised from `nn.py`: 
![image](https://user-images.githubusercontent.com/100642027/174346183-429185ac-d348-4524-90c7-f482e9e4d8fd.png)

The second bug fix is in the SimphonyWrapper class, where pins are defined as a tuple of str rather than PinList. Furthermore, some other attributes had to be added. 

![image](https://user-images.githubusercontent.com/100642027/174346611-0e05d55f-5bc4-425d-8083-949584887f59.png)
