### PR TITLE
fixing mistake in CI/CD pipeline

### DIFF
--- a/.github/workflows/continuous-integration-pip-master.yml
+++ b/.github/workflows/continuous-integration-pip-master.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10' ,'3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10' ,'3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration-pip.yml
+++ b/.github/workflows/continuous-integration-pip.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
python only supported up to 3.12 in latest versions of tensorflow